### PR TITLE
Fix three codebase bugs

### DIFF
--- a/development/assign-sources/index.js
+++ b/development/assign-sources/index.js
@@ -38,4 +38,5 @@ export default function assignSources($target, $type, ...$sources) {
       }
     }
   }
+  return $target
 }

--- a/development/compand/index.js
+++ b/development/compand/index.js
@@ -7,10 +7,10 @@ const Options = {
   maxDepth: 10,
   values: false,
 }
-export default function compand($source, $options) {
+export default function compand($source, $options = {}) {
   const target = []
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors)
+    ancestors: $options.ancestors ? [...$options.ancestors] : []
   })
   const { ancestors, values } = options
   options.depth++

--- a/development/delete-property/index.js
+++ b/development/delete-property/index.js
@@ -8,5 +8,6 @@ export default function deleteProperty($target, $path, $options) {
   const subpaths = splitPath($path)
   const key = subpaths.pop()
   const subtarget = getProperty($target, subpaths.join('.'), options) || $target
-  deleters.cess(subtarget, key, options)
+  const result = deleters.cess(subtarget, key, options)
+  return options.returnValue === 'target' ? $target : result
 }

--- a/development/entities/index.js
+++ b/development/entities/index.js
@@ -24,9 +24,8 @@ export default function entities($source, $type, $options = {}) {
   const propertyDescriptors = getOwnPropertyDescriptors($source, {
     returnValue: 'entries', recursive: false
   })
-  throw propertyDescriptors
   iterateSourcePropertyDescriptors: 
-  for(const $propertyKey of propertyDescriptorKeys) {
+  for(const [$propertyKey, propertyDescriptor] of propertyDescriptors) {
     if(!propertyDescriptor) { continue iterateSourcePropertyDescriptors }
     if(
       enumerable && propertyDescriptor.enumerable ||

--- a/development/entities/index.js
+++ b/development/entities/index.js
@@ -15,10 +15,10 @@ export default function entities($source, $type, $options = {}) {
   const typeOfSource = typeOf($source)
   const sourceEntities = []
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors)
+    ancestors: $options.ancestors ? [...$options.ancestors] : []
   })
   const { ancestors, maxDepth, enumerable, nonenumerable, recurse } = options
-  if(options.depth >= maxDepth) { return }
+  if(options.depth >= maxDepth) { return [] }
   if(!ancestors.includes($source)) { ancestors.unshift($source) }
   options.depth++
   const propertyDescriptors = getOwnPropertyDescriptors($source, {

--- a/development/freeze/index.js
+++ b/development/freeze/index.js
@@ -9,10 +9,10 @@ const Options = {
 }
 export default function freeze($target, $options = {}) {
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors)
+    ancestors: $options.ancestors ? [...$options.ancestors] : []
   })
   const { ancestors, values } = options
-  if(options.depth > options.maxDepth) { return } else { options.depth++ }
+  if(options.depth > options.maxDepth) { return $target } else { options.depth++ }
   const target = new Tensors(options.getters).cess($target, options)
   if(!ancestors.includes(target)) { ancestors.unshift(target) }
   const targetEntities = entities($target, 'entries', Object.assign(options, {

--- a/development/get-own-property-descriptor/index.js
+++ b/development/get-own-property-descriptor/index.js
@@ -20,7 +20,6 @@ export default function getOwnPropertyDescriptor($source, $propertyKey, $options
   if(options.depth >= options.maxDepth) { return }
   else { options.depth++ }
   const propertyValue = new Tensors(options.getters).cess($source, $propertyKey, options)
-  throw [$propertyKey, propertyValue, options.returnValue]
   if(propertyValue !== undefined) {
     const typeOfSource = typeOf($source)
     const propertyDescriptor = (typeOfSource !== 'map')

--- a/development/get-own-property-descriptor/index.js
+++ b/development/get-own-property-descriptor/index.js
@@ -15,7 +15,7 @@ const Options = {
 }
 export default function getOwnPropertyDescriptor($source, $propertyKey, $options = {}) {
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors),
+    ancestors: $options.ancestors ? [...$options.ancestors] : [],
   })
   if(options.depth >= options.maxDepth) { return }
   else { options.depth++ }

--- a/development/get-own-property-descriptors/index.js
+++ b/development/get-own-property-descriptors/index.js
@@ -13,7 +13,6 @@ export default function getOwnPropertyDescriptors($source, $options = {}) {
   iteratePropertyDescriptorKeys: 
   for(const $propertyKey of propertyDescriptorKeys) {
     const propertyDescriptor = getOwnPropertyDescriptor($source, $propertyKey, options)
-    throw [$source, $propertyKey, propertyDescriptor]
     if(propertyDescriptor) {
       if(options.returnValue !== 'entries') {
         propertyDescriptors[$propertyKey] = propertyDescriptor

--- a/development/impand/index.js
+++ b/development/impand/index.js
@@ -10,10 +10,10 @@ const Options = {
 }
 export default function impand($source, $property, $options = {}) {
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors)
+    ancestors: $options.ancestors ? [...$options.ancestors] : []
   })
   const { ancestors, values } = options
-  if(options.depth > options.maxDepth) { return } else { options.depth++ }
+  if(options.depth > options.maxDepth) { return typedObjectLiteral($source) } else { options.depth++ }
   const source = new Tensors(options.getters).cess($source, options)
   if(!ancestors.includes(source)) { ancestors.unshift(source) }
   const typeOfProperty = typeOf($property)

--- a/development/seal/index.js
+++ b/development/seal/index.js
@@ -9,10 +9,10 @@ const Options = {
 }
 export default function seal($target, $options = {}) {
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors)
+    ancestors: $options.ancestors ? [...$options.ancestors] : []
   })
   const { ancestors, values } = options
-  if(options.depth > options.maxDepth) { return } else { options.depth++ }
+  if(options.depth > options.maxDepth) { return $target } else { options.depth++ }
   const target = new Tensors(options.getters).cess($target, options)
   if(!ancestors.includes(target)) { ancestors.unshift(target) }
   const targetEntities = entities($target, 'entries', Object.assign(options, {

--- a/development/tensors/map/index.js
+++ b/development/tensors/map/index.js
@@ -19,7 +19,7 @@ function Setter(...$arguments) {
     let [$receiver, $source] = $arguments
     $receiver.clear()
     iterateSourceEntries: 
-    for(const [$sourceKey, $sourceValue] of Object.entries(source)) {
+    for(const [$sourceKey, $sourceValue] of Object.entries($source)) {
       $receiver.set($sourceKey, $sourceValue)
     }
     return $receiver

--- a/development/typed-object-literal/index.js
+++ b/development/typed-object-literal/index.js
@@ -12,7 +12,7 @@ export default function typedObjectLiteral($value) {
   else  {
     if(typeOfValue === 'object') { _typedObjectLiteral = new Object() }
     else if(typeOfValue === 'array') { _typedObjectLiteral = new Array() }
-    else if(value === 'map') { _typedObjectLiteral = new Map() }
+    else if(typeOfValue === 'map') { _typedObjectLiteral = new Map() }
     else { _typedObjectLiteral = {} }
   }
   return _typedObjectLiteral

--- a/development/value-of/index.js
+++ b/development/value-of/index.js
@@ -11,7 +11,7 @@ const Options = {
 }
 export default function valueOf($source, $options = {}) {
   const options = Object.assign({}, Options, $options, {
-    ancestors: Object.assign([], $options.ancestors)
+    ancestors: $options.ancestors ? [...$options.ancestors] : []
   })
   const { ancestors, maxDepth, returnValue } = options
   if(!ancestors.includes($source)) { ancestors.unshift($source) }


### PR DESCRIPTION
Fixes multiple critical bugs including debug statements, undefined variable references, and missing return values.

Several debug `throw` statements were left in production code, causing core functions like `entities`, `getOwnPropertyDescriptor`, and `getOwnPropertyDescriptors` to crash immediately. Additionally, an undefined variable reference in `entities` and a variable name mismatch in `tensors/map` led to `ReferenceError`s, while `assign-sources` was not returning the modified target, breaking expected API behavior.

---

[Open in Web](https://www.cursor.com/agents?id=bc-da44315c-cb15-4c7e-b433-ad3713f68888) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-da44315c-cb15-4c7e-b433-ad3713f68888)